### PR TITLE
Add trigram index for sub-second content search

### DIFF
--- a/src/service/background-indexer.js
+++ b/src/service/background-indexer.js
@@ -76,7 +76,7 @@ export class BackgroundIndexer {
       const insertStart = performance.now();
       console.log(`[Indexer] ${language} workers done: ${totalProcessed} files parsed, inserting into database...`);
 
-      const BATCH_SIZE = 500;
+      const BATCH_SIZE = 100;
       for (let i = 0; i < allFileResults.length; i += BATCH_SIZE) {
         const batch = allFileResults.slice(i, i + BATCH_SIZE);
 
@@ -111,6 +111,15 @@ export class BackgroundIndexer {
               }));
 
               this.database.insertMembers(fileId, resolvedMembers);
+            }
+
+            // Insert compressed content and trigrams for content search
+            if (fileResult.compressedContent) {
+              this.database.upsertFileContent(fileId, fileResult.compressedContent, fileResult.contentHash);
+              this.database.clearTrigramsForFile(fileId);
+              if (fileResult.trigrams && fileResult.trigrams.length > 0) {
+                this.database.insertTrigrams(fileId, fileResult.trigrams);
+              }
             }
           }
         });

--- a/src/service/trigram-build-worker.js
+++ b/src/service/trigram-build-worker.js
@@ -1,0 +1,29 @@
+import { parentPort, workerData } from 'worker_threads';
+import { readFileSync } from 'fs';
+import { deflateSync } from 'zlib';
+import { extractTrigrams, contentHash } from './trigram.js';
+
+const { files } = workerData;
+const results = [];
+
+for (const file of files) {
+  try {
+    const content = readFileSync(file.path, 'utf-8');
+    if (content.length > 500000) continue;
+
+    const trigrams = [...extractTrigrams(content)];
+    const compressed = deflateSync(content);
+    const hash = contentHash(content);
+
+    results.push({
+      fileId: file.id,
+      trigrams,
+      compressedContent: compressed,
+      contentHash: hash
+    });
+  } catch {
+    // skip unreadable files
+  }
+}
+
+parentPort.postMessage({ type: 'complete', results });

--- a/src/service/trigram.js
+++ b/src/service/trigram.js
@@ -1,0 +1,258 @@
+import { createHash } from 'crypto';
+
+/**
+ * Encode three characters into a 24-bit integer trigram.
+ */
+export function encodeTrigram(c1, c2, c3) {
+  return (c1 << 16) | (c2 << 8) | c3;
+}
+
+/**
+ * Extract all unique trigrams from file content.
+ * Content is lowercased before extraction (case-insensitive index).
+ * Returns a Set of integer-encoded trigrams.
+ */
+export function extractTrigrams(content) {
+  const lower = content.toLowerCase();
+  const trigrams = new Set();
+  const len = lower.length - 2;
+
+  for (let i = 0; i < len; i++) {
+    const c1 = lower.charCodeAt(i);
+    const c2 = lower.charCodeAt(i + 1);
+    const c3 = lower.charCodeAt(i + 2);
+
+    // Skip trigrams containing newlines, carriage returns, or null bytes
+    if (c1 === 10 || c1 === 13 || c1 === 0) continue;
+    if (c2 === 10 || c2 === 13 || c2 === 0) continue;
+    if (c3 === 10 || c3 === 13 || c3 === 0) continue;
+
+    trigrams.add((c1 << 16) | (c2 << 8) | c3);
+  }
+
+  return trigrams;
+}
+
+/**
+ * Compute a 64-bit content hash for change detection.
+ * Uses the first 8 bytes of an MD5 hash, read as a BigInt.
+ */
+export function contentHash(content) {
+  const hash = createHash('md5').update(content).digest();
+  // Read first 8 bytes as a signed 64-bit integer (SQLite stores as INTEGER)
+  return hash.readBigInt64LE(0);
+}
+
+/**
+ * Extract required trigrams from a search pattern.
+ * Returns an array of integer-encoded trigrams that ANY matching string must contain.
+ * Returns empty array for unindexable patterns.
+ */
+export function patternToTrigrams(pattern, isRegex = true) {
+  if (!isRegex) {
+    // Literal string: extract all trigrams directly
+    return [...extractTrigrams(pattern)];
+  }
+
+  // Handle top-level alternation at the trigram level (intersection)
+  const alternatives = splitTopLevelAlternation(pattern);
+  if (alternatives.length > 1) {
+    const branchTrigramSets = alternatives.map(alt => {
+      const literals = extractLiteralsFromBranch(alt);
+      if (literals.length === 0) return new Set();
+      const set = new Set();
+      for (const lit of literals) {
+        for (const tri of extractTrigrams(lit)) {
+          set.add(tri);
+        }
+      }
+      return set;
+    });
+
+    // If any branch is unindexable, the whole alternation is unindexable
+    if (branchTrigramSets.some(s => s.size === 0)) return [];
+
+    // Intersect all branch trigram sets
+    let common = branchTrigramSets[0];
+    for (let i = 1; i < branchTrigramSets.length; i++) {
+      common = new Set([...common].filter(t => branchTrigramSets[i].has(t)));
+    }
+
+    return [...common];
+  }
+
+  // Single branch: extract literal fragments, then get trigrams from each
+  const literals = extractLiteralsFromRegex(pattern);
+  if (literals.length === 0) return [];
+
+  // Collect trigrams from all literal fragments (AND semantics)
+  const allTrigrams = new Set();
+  for (const lit of literals) {
+    for (const tri of extractTrigrams(lit)) {
+      allTrigrams.add(tri);
+    }
+  }
+
+  return [...allTrigrams];
+}
+
+/**
+ * Extract required literal substrings from a regex pattern.
+ *
+ * Strategy (based on Google Code Search approach):
+ * - Split on metacharacters to find contiguous literal runs
+ * - Handle alternation: take intersection of trigrams from each branch
+ * - Handle escaped characters (\. \( etc.) as literals
+ * - Keep fragments >= 3 chars (needed for at least one trigram)
+ */
+export function extractLiteralsFromRegex(pattern) {
+  // Handle top-level alternation by recursing into branches
+  const alternatives = splitTopLevelAlternation(pattern);
+  if (alternatives.length > 1) {
+    // For alternation at this level, return empty — alternation is handled
+    // by patternToTrigrams at the trigram level (intersection).
+    return [];
+  }
+
+  return extractLiteralsFromBranch(pattern);
+}
+
+/**
+ * Extract literal fragments from a single regex branch (no top-level alternation).
+ */
+function extractLiteralsFromBranch(pattern) {
+  // Single branch: extract literal fragments by walking the pattern
+  const fragments = [];
+  let current = '';
+  let i = 0;
+
+  while (i < pattern.length) {
+    const ch = pattern[i];
+
+    if (ch === '\\' && i + 1 < pattern.length) {
+      const next = pattern[i + 1];
+      // Common regex escapes that represent literal characters
+      if ('.()[]{}*+?|^$'.includes(next)) {
+        current += next;
+        i += 2;
+        continue;
+      }
+      // \w, \d, \s, \b etc. break the literal run
+      flushFragment(current, fragments);
+      current = '';
+      i += 2;
+      continue;
+    }
+
+    if (ch === '[') {
+      // Character class — skip until closing ]
+      flushFragment(current, fragments);
+      current = '';
+      i++;
+      if (i < pattern.length && pattern[i] === '^') i++;
+      if (i < pattern.length && pattern[i] === ']') i++;
+      while (i < pattern.length && pattern[i] !== ']') i++;
+      i++; // skip ]
+      continue;
+    }
+
+    if (ch === '(' || ch === ')') {
+      // Groups — don't break literals, just skip the metachar
+      flushFragment(current, fragments);
+      current = '';
+      i++;
+      // Skip non-capturing group syntax (?:, (?=, (?!, etc.
+      if (ch === '(' && i < pattern.length && pattern[i] === '?') {
+        i++;
+        while (i < pattern.length && pattern[i] !== ')' && pattern[i] !== ':' && !isAlpha(pattern[i])) i++;
+        if (i < pattern.length && pattern[i] === ':') i++;
+      }
+      continue;
+    }
+
+    if ('.+*?{^$'.includes(ch)) {
+      // Metacharacter — breaks literal run
+      flushFragment(current, fragments);
+      current = '';
+      i++;
+      // Skip quantifier ranges like {2,3}
+      if (ch === '{') {
+        while (i < pattern.length && pattern[i] !== '}') i++;
+        if (i < pattern.length) i++;
+      }
+      continue;
+    }
+
+    // Regular literal character
+    current += ch;
+    i++;
+  }
+
+  flushFragment(current, fragments);
+  return fragments;
+}
+
+function flushFragment(str, fragments) {
+  if (str.length >= 3) {
+    fragments.push(str);
+  }
+}
+
+function isAlpha(ch) {
+  return (ch >= 'a' && ch <= 'z') || (ch >= 'A' && ch <= 'Z');
+}
+
+/**
+ * Split a regex pattern on top-level (unescaped, un-grouped) pipe characters.
+ */
+function splitTopLevelAlternation(pattern) {
+  const parts = [];
+  let current = '';
+  let depth = 0;
+  let inCharClass = false;
+
+  for (let i = 0; i < pattern.length; i++) {
+    const ch = pattern[i];
+
+    if (ch === '\\' && i + 1 < pattern.length) {
+      current += ch + pattern[i + 1];
+      i++;
+      continue;
+    }
+
+    if (inCharClass) {
+      current += ch;
+      if (ch === ']') inCharClass = false;
+      continue;
+    }
+
+    if (ch === '[') {
+      inCharClass = true;
+      current += ch;
+      continue;
+    }
+
+    if (ch === '(') {
+      depth++;
+      current += ch;
+      continue;
+    }
+
+    if (ch === ')') {
+      depth--;
+      current += ch;
+      continue;
+    }
+
+    if (ch === '|' && depth === 0) {
+      parts.push(current);
+      current = '';
+      continue;
+    }
+
+    current += ch;
+  }
+
+  parts.push(current);
+  return parts;
+}

--- a/test-trigram-db.js
+++ b/test-trigram-db.js
@@ -1,0 +1,154 @@
+import { IndexDatabase } from './src/service/database.js';
+import { extractTrigrams, contentHash } from './src/service/trigram.js';
+import { deflateSync, inflateSync } from 'zlib';
+import { join, dirname } from 'path';
+import { unlinkSync } from 'fs';
+import { fileURLToPath } from 'url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+const testDbPath = join(__dirname, 'data', 'test-trigram.db');
+
+// Clean up from previous runs
+try { unlinkSync(testDbPath); } catch {}
+
+let passed = 0;
+let failed = 0;
+
+function test(name, fn) {
+  try {
+    fn();
+    console.log(`  [PASS] ${name}`);
+    passed++;
+  } catch (e) {
+    console.log(`  [FAIL] ${name}: ${e.message}`);
+    failed++;
+  }
+}
+
+function assert(cond, msg) {
+  if (!cond) throw new Error(msg || 'assertion failed');
+}
+
+console.log('\nTrigram Database Integration Tests\n');
+
+const db = new IndexDatabase(testDbPath);
+db.open();
+
+test('trigram tables exist', () => {
+  assert(db.hasTrigramTables(), 'file_content table should exist');
+});
+
+test('trigramBuildNeeded flag is set on fresh db', () => {
+  const needed = db.getMetadata('trigramBuildNeeded');
+  assert(needed === true, `Expected true, got ${needed}`);
+});
+
+test('isTrigramIndexReady returns false when build needed', () => {
+  assert(!db.isTrigramIndexReady(), 'Should not be ready');
+});
+
+// Insert a test file
+const fileId = db.upsertFile('/test/foo.as', 'TestProject', 'TestProject.Foo', Date.now(), 'angelscript');
+
+test('upsertFileContent works', () => {
+  const content = 'class AMyActor : AActor\n{\n  void DestroyActor() {}\n}\n';
+  const compressed = deflateSync(content);
+  const hash = contentHash(content);
+  db.upsertFileContent(fileId, compressed, hash);
+
+  const stored = db.getFileContent(fileId);
+  assert(stored, 'Should have stored content');
+  const decompressed = inflateSync(stored.content).toString('utf-8');
+  assert(decompressed === content, 'Content round-trip should match');
+});
+
+test('insertTrigrams works', () => {
+  const content = 'class AMyActor : AActor\n{\n  void DestroyActor() {}\n}\n';
+  const trigrams = [...extractTrigrams(content)];
+  db.clearTrigramsForFile(fileId);
+  db.insertTrigrams(fileId, trigrams);
+
+  const stats = db.getTrigramStats();
+  assert(stats.filesWithContent === 1, `Expected 1 file, got ${stats.filesWithContent}`);
+  assert(stats.trigramRows > 0, `Expected trigram rows, got ${stats.trigramRows}`);
+});
+
+test('queryTrigramCandidates finds file by trigrams', () => {
+  const searchTrigrams = [...extractTrigrams('destroyactor')];
+  const candidates = db.queryTrigramCandidates(searchTrigrams, {});
+  assert(candidates.length === 1, `Expected 1 candidate, got ${candidates.length}`);
+  assert(candidates[0].path === '/test/foo.as', `Wrong path: ${candidates[0].path}`);
+});
+
+test('queryTrigramCandidates filters by project', () => {
+  const searchTrigrams = [...extractTrigrams('destroyactor')];
+  const candidates = db.queryTrigramCandidates(searchTrigrams, { project: 'TestProject' });
+  assert(candidates.length === 1, `Expected 1, got ${candidates.length}`);
+
+  const none = db.queryTrigramCandidates(searchTrigrams, { project: 'NoSuchProject' });
+  assert(none.length === 0, `Expected 0, got ${none.length}`);
+});
+
+test('queryTrigramCandidates returns no candidates for non-matching trigrams', () => {
+  const searchTrigrams = [...extractTrigrams('zzzzzzzzz')];
+  const candidates = db.queryTrigramCandidates(searchTrigrams, {});
+  assert(candidates.length === 0, `Expected 0, got ${candidates.length}`);
+});
+
+test('queryTrigramCandidates with empty trigrams returns all files', () => {
+  const candidates = db.queryTrigramCandidates([], {});
+  assert(candidates.length === 1, `Expected 1, got ${candidates.length}`);
+});
+
+// Insert a second file
+const fileId2 = db.upsertFile('/test/bar.as', 'TestProject', 'TestProject.Bar', Date.now(), 'angelscript');
+const content2 = 'class ABotPawn : APawn\n{\n  void UpdateAI() {}\n}\n';
+const compressed2 = deflateSync(content2);
+db.upsertFileContent(fileId2, compressed2, contentHash(content2));
+db.insertTrigrams(fileId2, [...extractTrigrams(content2)]);
+
+test('queryTrigramCandidates narrows to correct file', () => {
+  const destroyTrigrams = [...extractTrigrams('destroyactor')];
+  const candidates = db.queryTrigramCandidates(destroyTrigrams, {});
+  assert(candidates.length === 1, `Expected 1 (only foo.as), got ${candidates.length}`);
+  assert(candidates[0].path === '/test/foo.as', `Wrong file: ${candidates[0].path}`);
+});
+
+test('getFilesWithoutContent finds missing files', () => {
+  db.upsertFile('/test/baz.as', 'TestProject', 'TestProject.Baz', Date.now(), 'angelscript');
+  const missing = db.getFilesWithoutContent();
+  assert(missing.length === 1, `Expected 1 missing, got ${missing.length}`);
+  assert(missing[0].path === '/test/baz.as', `Wrong path: ${missing[0].path}`);
+});
+
+test('getFileContentBatch returns map', () => {
+  const batch = db.getFileContentBatch([fileId, fileId2]);
+  assert(batch.size === 2, `Expected 2 entries, got ${batch.size}`);
+  assert(batch.has(fileId), 'Should have fileId');
+  assert(batch.has(fileId2), 'Should have fileId2');
+});
+
+test('cascade delete removes content', () => {
+  db.deleteFile('/test/foo.as');
+
+  const content = db.getFileContent(fileId);
+  assert(!content, 'file_content should be cascade deleted');
+
+  const file = db.getFileByPath('/test/foo.as');
+  assert(!file, 'File should be deleted');
+});
+
+test('setMetadata clears trigramBuildNeeded', () => {
+  db.setMetadata('trigramBuildNeeded', false);
+  assert(db.isTrigramIndexReady(), 'Should be ready after clearing flag');
+});
+
+db.close();
+
+// Clean up
+try { unlinkSync(testDbPath); } catch {}
+
+console.log(`\n--- Results: ${passed}/${passed + failed} passed ---\n`);
+process.exit(failed > 0 ? 1 : 0);

--- a/test-trigram-grep.js
+++ b/test-trigram-grep.js
@@ -1,0 +1,253 @@
+/**
+ * End-to-end test for the trigram-powered grep flow.
+ * Tests: trigram extraction in worker -> DB insert -> query candidates -> grep worker -> results
+ */
+import { IndexDatabase } from './src/service/database.js';
+import { extractTrigrams, contentHash, patternToTrigrams } from './src/service/trigram.js';
+import { deflateSync, inflateSync } from 'zlib';
+import { Worker } from 'worker_threads';
+import { join, dirname } from 'path';
+import { unlinkSync } from 'fs';
+import { fileURLToPath } from 'url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+const testDbPath = join(__dirname, 'data', 'test-grep.db');
+try { unlinkSync(testDbPath); } catch {}
+
+let passed = 0;
+let failed = 0;
+
+function test(name, fn) {
+  return fn().then(() => {
+    console.log(`  [PASS] ${name}`);
+    passed++;
+  }).catch(e => {
+    console.log(`  [FAIL] ${name}: ${e.message}`);
+    failed++;
+  });
+}
+
+function assert(cond, msg) {
+  if (!cond) throw new Error(msg || 'assertion failed');
+}
+
+function runGrepWorker(workerData) {
+  return new Promise((resolve, reject) => {
+    const workerPath = join(__dirname, 'src', 'service', 'grep-worker.js');
+    const worker = new Worker(workerPath, { workerData });
+    worker.on('message', msg => {
+      if (msg.type === 'complete') resolve(msg);
+    });
+    worker.on('error', reject);
+  });
+}
+
+console.log('\nTrigram Grep End-to-End Tests\n');
+
+const db = new IndexDatabase(testDbPath);
+db.open();
+
+// Mark trigram index as ready
+db.setMetadata('trigramBuildNeeded', false);
+
+// Create test files with realistic content
+const files = [
+  {
+    path: '/test/PlayerCharacter.as',
+    project: 'TestProject',
+    language: 'angelscript',
+    content: `class APlayerCharacter : ACharacter
+{
+  UPROPERTY(EditAnywhere)
+  float MaxHealth = 100.0f;
+
+  void DestroyActor()
+  {
+    // Custom destroy logic
+    Super::DestroyActor();
+  }
+
+  void SetTimer(float Duration)
+  {
+    FTimerHandle Handle;
+    System::SetTimer(Handle, Duration, false);
+  }
+}
+`
+  },
+  {
+    path: '/test/EnemyPawn.as',
+    project: 'TestProject',
+    language: 'angelscript',
+    content: `class AEnemyPawn : APawn
+{
+  void DestroyPawn()
+  {
+    // Custom pawn removal logic
+    Destroy();
+  }
+}
+`
+  },
+  {
+    path: '/test/GameMode.as',
+    project: 'TestProject',
+    language: 'angelscript',
+    content: `class AMyGameMode : AGameModeBase
+{
+  void StartGame()
+  {
+    Print("Game started!");
+  }
+}
+`
+  }
+];
+
+// Index all files
+for (const file of files) {
+  const fileId = db.upsertFile(file.path, file.project, `${file.project}.Test`, Date.now(), file.language);
+  const compressed = deflateSync(file.content);
+  const hash = contentHash(file.content);
+  const trigrams = [...extractTrigrams(file.content)];
+
+  db.upsertFileContent(fileId, compressed, hash);
+  db.insertTrigrams(fileId, trigrams);
+}
+
+await test('patternToTrigrams handles alternation with no common trigrams', async () => {
+  // 4 branches with very different content — intersection is empty (unindexable)
+  const trigrams = patternToTrigrams('DestroyActor|DestroyPawn|SetTimer|FTimerHandle', true);
+  assert(trigrams.length === 0, `Expected 0 (unindexable alternation), got ${trigrams.length}`);
+
+  // 2 branches with common prefix — should find common trigrams
+  const trigrams2 = patternToTrigrams('DestroyActor|DestroyPawn', true);
+  assert(trigrams2.length > 0, `Expected common trigrams from Destroy*, got ${trigrams2.length}`);
+});
+
+await test('queryTrigramCandidates with DestroyActor finds correct files', async () => {
+  const trigrams = patternToTrigrams('DestroyActor', true);
+  const candidates = db.queryTrigramCandidates(trigrams, {});
+  assert(candidates.length === 1, `Expected 1 candidate, got ${candidates.length}`);
+  assert(candidates[0].path === '/test/PlayerCharacter.as', `Wrong file: ${candidates[0].path}`);
+});
+
+await test('grep worker finds matches from compressed content', async () => {
+  const trigrams = patternToTrigrams('DestroyActor', true);
+  const candidates = db.queryTrigramCandidates(trigrams, {});
+
+  const result = await runGrepWorker({
+    candidates: candidates.map(c => ({
+      content: c.content,
+      path: c.path,
+      project: c.project,
+      language: c.language
+    })),
+    pattern: 'DestroyActor',
+    flags: '',
+    maxResults: 50,
+    contextLines: 2,
+    literals: null
+  });
+
+  assert(result.results.length > 0, `Expected matches, got ${result.results.length}`);
+  assert(result.results[0].file === '/test/PlayerCharacter.as', `Wrong file: ${result.results[0].file}`);
+  assert(result.filesSearched === 1, `Expected 1 file searched, got ${result.filesSearched}`);
+});
+
+await test('alternation pattern query returns correct candidates', async () => {
+  const trigrams = patternToTrigrams('DestroyActor|DestroyPawn', true);
+  const candidates = db.queryTrigramCandidates(trigrams, {});
+  // Both alternatives share "estroy" trigrams; both files should match
+  // But "destroyactor" only appears in PlayerCharacter, "destroypawn" only in EnemyPawn
+  // The trigram intersection of the branches should find common trigrams
+  // If the pattern extracts common trigrams like "des", "est", "str", "tro", "roy"
+  // then both files containing "destroy*" should be candidates
+  assert(candidates.length >= 1, `Expected at least 1 candidate, got ${candidates.length}`);
+});
+
+await test('grep worker with alternation finds matches in both files', async () => {
+  // For the alternation, use empty trigrams to get all files (worst case),
+  // then let the worker filter
+  const trigrams = patternToTrigrams('DestroyActor|DestroyPawn', true);
+  const candidates = db.queryTrigramCandidates(trigrams, {});
+
+  const result = await runGrepWorker({
+    candidates: candidates.map(c => ({
+      content: c.content,
+      path: c.path,
+      project: c.project,
+      language: c.language
+    })),
+    pattern: 'DestroyActor|DestroyPawn',
+    flags: '',
+    maxResults: 50,
+    contextLines: 2,
+    literals: null
+  });
+
+  const matchFiles = new Set(result.results.map(r => r.file));
+  assert(matchFiles.has('/test/PlayerCharacter.as'), 'Should find PlayerCharacter.as');
+  assert(matchFiles.has('/test/EnemyPawn.as'), 'Should find EnemyPawn.as');
+  assert(!matchFiles.has('/test/GameMode.as'), 'Should NOT find GameMode.as');
+});
+
+await test('grep worker case-insensitive', async () => {
+  const trigrams = patternToTrigrams('destroyactor', true);
+  const candidates = db.queryTrigramCandidates(trigrams, {});
+
+  const result = await runGrepWorker({
+    candidates: candidates.map(c => ({
+      content: c.content,
+      path: c.path,
+      project: c.project,
+      language: c.language
+    })),
+    pattern: 'destroyactor',
+    flags: 'i',
+    maxResults: 50,
+    contextLines: 2,
+    literals: null
+  });
+
+  assert(result.results.length > 0, 'Case-insensitive search should find matches');
+});
+
+await test('unindexable pattern falls back to all files', async () => {
+  const trigrams = patternToTrigrams('.*', true);
+  assert(trigrams.length === 0, 'Should be unindexable');
+
+  const candidates = db.queryTrigramCandidates(trigrams, {});
+  assert(candidates.length === 3, `Should return all 3 files, got ${candidates.length}`);
+});
+
+await test('project filter works with trigram query', async () => {
+  const trigrams = patternToTrigrams('DestroyActor', true);
+  const candidates = db.queryTrigramCandidates(trigrams, { project: 'NoSuchProject' });
+  assert(candidates.length === 0, `Expected 0, got ${candidates.length}`);
+});
+
+await test('grep worker fallback mode (files) still works', async () => {
+  // This tests the non-trigram path where files are read from disk
+  // We can't test actual disk reads without real files, but we test
+  // that the worker handles the empty files array gracefully
+  const result = await runGrepWorker({
+    files: [],
+    pattern: 'test',
+    flags: '',
+    maxResults: 50,
+    contextLines: 2,
+    literals: null
+  });
+
+  assert(result.results.length === 0, 'Empty files should yield no results');
+  assert(result.filesSearched === 0, 'Should search 0 files');
+});
+
+db.close();
+try { unlinkSync(testDbPath); } catch {}
+
+console.log(`\n--- Results: ${passed}/${passed + failed} passed ---\n`);
+process.exit(failed > 0 ? 1 : 0);

--- a/test-trigram.js
+++ b/test-trigram.js
@@ -1,0 +1,100 @@
+import { extractTrigrams, patternToTrigrams, contentHash, encodeTrigram } from './src/service/trigram.js';
+
+let passed = 0;
+let failed = 0;
+
+function test(name, fn) {
+  try {
+    fn();
+    console.log(`  [PASS] ${name}`);
+    passed++;
+  } catch (e) {
+    console.log(`  [FAIL] ${name}: ${e.message}`);
+    failed++;
+  }
+}
+
+function assert(cond, msg) {
+  if (!cond) throw new Error(msg || 'assertion failed');
+}
+
+console.log('\nTrigram Module Tests\n');
+
+test('extractTrigrams returns trigrams', () => {
+  const tri = extractTrigrams('Hello World');
+  assert(tri.size > 0, `Expected trigrams, got ${tri.size}`);
+});
+
+test('extractTrigrams is case-insensitive', () => {
+  const tri1 = extractTrigrams('ABC');
+  const tri2 = extractTrigrams('abc');
+  assert(tri1.size === tri2.size, 'Different sizes');
+  const [v1] = tri1;
+  const [v2] = tri2;
+  assert(v1 === v2, 'Different values');
+});
+
+test('extractTrigrams skips newlines', () => {
+  const tri = extractTrigrams('ab\ncd');
+  assert(tri.size === 0, `Expected 0, got ${tri.size}`);
+});
+
+test('extractTrigrams counts correctly for short string', () => {
+  const tri = extractTrigrams('abcde');
+  assert(tri.size === 3, `Expected 3, got ${tri.size}`);
+});
+
+test('encodeTrigram packs correctly', () => {
+  const t = encodeTrigram(0x61, 0x62, 0x63);
+  assert(t === (0x61 << 16 | 0x62 << 8 | 0x63), 'Bad encoding');
+});
+
+test('contentHash is consistent', () => {
+  const h1 = contentHash('hello');
+  const h2 = contentHash('hello');
+  assert(h1 === h2, 'Same content should give same hash');
+});
+
+test('contentHash is unique', () => {
+  const h1 = contentHash('hello');
+  const h3 = contentHash('world');
+  assert(h1 !== h3, 'Different content should give different hash');
+});
+
+test('patternToTrigrams literal string', () => {
+  const tri = patternToTrigrams('DestroyActor', false);
+  assert(tri.length === 10, `Expected 10, got ${tri.length}`);
+});
+
+test('patternToTrigrams simple regex with literal parts', () => {
+  const tri = patternToTrigrams('UPROPERTY.*EditAnywhere');
+  assert(tri.length > 0, `Expected >0, got ${tri.length}`);
+});
+
+test('patternToTrigrams unindexable pattern', () => {
+  const tri = patternToTrigrams('.*');
+  assert(tri.length === 0, `Expected 0, got ${tri.length}`);
+});
+
+test('patternToTrigrams regex alternation with common prefix', () => {
+  const tri = patternToTrigrams('DestroyActor|DestroyPawn');
+  assert(tri.length > 0, `Expected >0, got ${tri.length}`);
+});
+
+test('patternToTrigrams short alternation branches', () => {
+  const tri = patternToTrigrams('a|b');
+  assert(tri.length === 0, `Expected 0, got ${tri.length}`);
+});
+
+test('patternToTrigrams escaped metachar', () => {
+  const tri = patternToTrigrams('foo\\.bar');
+  assert(tri.length === 5, `Expected 5, got ${tri.length}`);
+});
+
+test('patternToTrigrams character class breaks literal', () => {
+  const tri = patternToTrigrams('abc[xyz]def');
+  assert(tri.length === 2, `Expected 2, got ${tri.length}`);
+});
+
+console.log(`\n--- Results: ${passed}/${passed + failed} passed ---\n`);
+process.exit(failed > 0 ? 1 : 0);


### PR DESCRIPTION
## Summary

- Adds a trigram index that eliminates filesystem reads at grep query time, delivering sub-second search across 69K+ files
- Pre-indexes file content with compressed storage (zlib) and a trigram posting index (72M+ entries) in SQLite
- Pattern → trigrams → candidate files from DB → decompress → regex verify — zero disk I/O at query time
- Handles regex alternation via trigram set intersection, falls back gracefully for unindexable patterns

### Performance results (Discovery angelscript, maxResults=30)

| Query | Before | After | Speedup |
|-------|--------|-------|---------|
| `DestroyActor` (literal) | ~20s | **160ms** | 125x |
| `DestroyActor\|DestroyPawn` | ~20s | **150ms** | 133x |
| `UPROPERTY.*EditAnywhere` | ~20s | **261ms** | 77x |
| 4-way alternation (original bug) | **187,393ms** | **582ms** | 321x |

### Changes

- **`src/service/trigram.js`** — NEW: trigram extraction, encoding, pattern-to-trigrams with regex literal extraction
- **`src/service/trigram-build-worker.js`** — NEW: worker for one-time migration build
- **`src/service/database.js`** — file_content + trigrams tables (WITHOUT ROWID), CRUD methods, candidate query
- **`src/service/index-worker.js`** — extracts trigrams + compresses content during indexing
- **`src/service/background-indexer.js`** — inserts content + trigrams in batch transaction loop
- **`src/service/watcher.js`** — trigram extraction on file add/change
- **`src/service/grep-worker.js`** — accepts pre-fetched compressed content or falls back to disk
- **`src/service/api.js`** — trigram query flow when index is ready, disk fallback otherwise
- **`src/service/index.js`** — migration: wave-based background trigram build with event loop yields

### Database impact

- DB grows from ~460MB to ~2.4GB (compressed content + 72M trigram posting entries)
- One-time migration build: ~24 minutes (P4 drive I/O bound, runs in background)
- Incremental updates via file watcher are instant

## Test plan

- [x] 14 trigram unit tests pass (`test-trigram.js`)
- [x] 14 database integration tests pass (`test-trigram-db.js`)
- [x] 9 end-to-end grep flow tests pass (`test-trigram-grep.js`)
- [x] Live service test: all grep queries return correct results in <1s
- [x] Health endpoint stays responsive during trigram build
- [x] Migration build completes successfully for 69K files

🤖 Generated with [Claude Code](https://claude.com/claude-code)