### PR TITLE
Fix Claude review workflow permissions

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -4,6 +4,9 @@ on:
   pull_request:
     types: [opened, ready_for_review]
 
+permissions:
+  pull-requests: write
+
 jobs:
   request-claude-review:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- Add `pull-requests: write` permission to the Claude review workflow

The workflow was failing with `403 Resource not accessible by integration` because the default GitHub Actions token for `pull_request` events has read-only permissions.

## Test plan
- [ ] Merge this PR and verify the workflow succeeds on subsequent PRs

🤖 Generated with [Claude Code](https://claude.com/claude-code)