### PR TITLE
Add timestamps to query log messages

### DIFF
--- a/src/service/api.js
+++ b/src/service/api.js
@@ -19,7 +19,7 @@ export function createApi(database, indexer) {
     res.on('finish', () => {
       const ms = (performance.now() - start).toFixed(1);
       const query = req.url.includes('?') ? req.url.slice(req.url.indexOf('?')) : '';
-      console.log(`[API] ${req.method} ${req.path}${query} — ${ms}ms (${res.statusCode})`);
+      console.log(`[${new Date().toISOString()}] [API] ${req.method} ${req.path}${query} — ${ms}ms (${res.statusCode})`);
     });
     next();
   });
@@ -69,7 +69,7 @@ export function createApi(database, indexer) {
       const trigramReady = database.isTrigramIndexReady();
       statsCache = { ...stats, lastBuild, indexStatus, trigram: trigramStats ? { ...trigramStats, ready: trigramReady } : null };
     } catch (err) {
-      console.error('[Stats] cache refresh failed:', err.message);
+      console.error(`[${new Date().toISOString()}] [Stats] cache refresh failed:`, err.message);
     }
   }
 

--- a/src/service/database.js
+++ b/src/service/database.js
@@ -1317,7 +1317,7 @@ for (const method of methodsToTime) {
     const ms = performance.now() - start;
     if (ms >= SLOW_QUERY_MS) {
       const arg0 = typeof args[0] === 'string' ? `"${args[0]}"` : Array.isArray(args[0]) ? `[${args[0].length} items]` : '';
-      console.log(`[DB] ${method}(${arg0}) — ${ms.toFixed(1)}ms`);
+      console.log(`[${new Date().toISOString()}] [DB] ${method}(${arg0}) — ${ms.toFixed(1)}ms`);
     }
     return result;
   };


### PR DESCRIPTION
## Summary
- Add ISO 8601 timestamps to query-related log messages (`[API]`, `[DB]`, `[Stats]` prefixes)
- Helps with debugging and correlating log events

## Example output
```
[2026-02-05T14:30:45.123Z] [API] GET /find-type?name=AActor — 125.3ms (200)
[2026-02-05T14:30:45.250Z] [DB] findTypeByName("AActor") — 150.2ms
```

## Test plan
- [ ] Start the service and verify timestamps appear in console output
- [ ] Trigger a slow query (>100ms) to verify [DB] timestamps

🤖 Generated with [Claude Code](https://claude.com/claude-code)