### PR TITLE
Fix .mcp.json to use mcpServers format and bridge path

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -1,6 +1,8 @@
 {
-  "unreal-index": {
-    "command": "node",
-    "args": ["D:\\p4\\games\\Games\\Tools\\unreal-index\\src\\server.js"]
+  "mcpServers": {
+    "unreal-index": {
+      "command": "node",
+      "args": ["src/bridge/mcp-bridge.js"]
+    }
   }
 }


### PR DESCRIPTION
## Summary
- Added required `mcpServers` wrapper object to `.mcp.json` (Claude Code expects this format)
- Changed entry point from hardcoded `D:\p4\...\server.js` (legacy, user-specific) to relative `src/bridge/mcp-bridge.js`

This fixes Claude Code failing to discover and connect to the unreal-index MCP server.

## Test plan
- [ ] Run `claude mcp list` and verify unreal-index shows as connected
- [ ] Verify unreal-index MCP tools work (e.g. `unreal_find_type`)

Generated with [Claude Code](https://claude.com/claude-code)
