### PR TITLE
Use shared CI/CD workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,22 @@
+name: CI
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  ci:
+    uses: EmbarkStudios/johlander-claude-workflows/.github/workflows/node-ci.yml@main
+    with:
+      node_version: '22'
+      lint_command: ''
+      typecheck_command: ''
+      build_command: ''
+      test_command: 'npm test'
+      security_audit: true

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -7,30 +7,13 @@ on:
 jobs:
   review:
     if: github.event.pull_request.draft == false
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      pull-requests: write
-      issues: write
-      id-token: write
-      actions: read
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 1
-
-      - name: Run Claude PR Review
-        uses: anthropics/claude-code-action@v1
-        with:
-          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          claude_args: "--model sonnet"
-          prompt: |
-            Review this PR. Focus on:
-            - Code quality and potential bugs
-            - Security issues
-            - Test coverage gaps
-            Approve the PR if everything looks good, or request changes if there are issues.
-          additional_permissions: |
-            actions: read
-            pull-requests: write
+    uses: EmbarkStudios/johlander-claude-workflows/.github/workflows/claude-code-review.yml@main
+    with:
+      review_prompt: |
+        Review this PR. Focus on:
+        - Code quality and potential bugs
+        - Security issues
+        - Test coverage gaps
+        Approve the PR if everything looks good, or request changes if there are issues.
+    secrets:
+      CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -12,32 +12,8 @@ on:
 
 jobs:
   claude:
-    if: |
-      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
-      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
-      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
-      (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
-    runs-on: ubuntu-latest
-    permissions:
-      contents: write
-      pull-requests: write
-      issues: write
-      id-token: write
-      actions: read
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 1
-
-      - name: Run Claude Code
-        id: claude
-        uses: anthropics/claude-code-action@v1
-        with:
-          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          claude_args: "--model sonnet"
-          additional_permissions: |
-            actions: read
-            contents: write
-            pull-requests: write
-            issues: write
+    uses: EmbarkStudios/johlander-claude-workflows/.github/workflows/claude-interactive.yml@main
+    with:
+      claude_args: "--model sonnet"
+    secrets:
+      CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}


### PR DESCRIPTION
## Summary
- Replace inline Claude review workflow with shared `claude-code-review.yml` from `EmbarkStudios/johlander-claude-workflows`
- Replace inline Claude interactive workflow with shared `claude-interactive.yml` (with `contents: write` support)
- Add new CI pipeline using shared `node-ci.yml` — runs `npm test` and `npm audit` on PRs/pushes to main

## Prerequisite
The shared workflows repo access level must be set to `organization` for cross-repo reusable workflow calls.

## Test plan
- [ ] Verify CI workflow triggers on this PR (tests pass, security audit runs)
- [ ] Verify Claude code review triggers on this PR
- [ ] Verify `@claude` interactive still works via PR comment

🤖 Generated with [Claude Code](https://claude.com/claude-code)