### PR TITLE
Fix code review findings: shared countBraces, deduplicated poll loops

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -179,6 +179,29 @@
       });
     }
 
+    async function waitForWatcherState(targetActive, { maxAttempts = 30, intervalMs = 2000 } = {}) {
+      for (let i = 0; i < maxAttempts; i++) {
+        await new Promise(r => setTimeout(r, intervalMs));
+        try {
+          const sr = await WorkspaceContext.serviceFetch('/watcher-status');
+          const sd = await sr.json();
+          if (sd.hasActiveWatcher === targetActive) return true;
+        } catch {}
+      }
+      return false;
+    }
+
+    async function waitForServiceHealth({ maxAttempts = 30, intervalMs = 2000 } = {}) {
+      for (let i = 0; i < maxAttempts; i++) {
+        await new Promise(r => setTimeout(r, intervalMs));
+        try {
+          const resp = await WorkspaceContext.serviceFetch('/health');
+          if (resp.ok) return true;
+        } catch {}
+      }
+      return false;
+    }
+
     async function startWatcher() {
       const btn = document.getElementById('start-watcher-btn');
       const msg = document.getElementById('start-watcher-msg');
@@ -197,23 +220,13 @@
           return;
         }
         if (msg) msg.textContent = 'Started! Waiting for heartbeat...';
-        let attempts = 0;
-        const poll = setInterval(async () => {
-          attempts++;
-          try {
-            const sr = await WorkspaceContext.serviceFetch('/watcher-status');
-            const sd = await sr.json();
-            if (sd.hasActiveWatcher) {
-              clearInterval(poll);
-              loadWatcher();
-            }
-          } catch {}
-          if (attempts >= 30) {
-            clearInterval(poll);
-            if (msg) msg.textContent = 'Started but still reconciling — refresh shortly';
-            if (btn) btn.disabled = false;
-          }
-        }, 2000);
+        const ok = await waitForWatcherState(true);
+        if (ok) {
+          loadWatcher();
+        } else {
+          if (msg) msg.textContent = 'Started but still reconciling \u2014 refresh shortly';
+          if (btn) btn.disabled = false;
+        }
       } catch (err) {
         if (msg) msg.textContent = err.name === 'TypeError'
           ? 'Setup GUI not reachable. Ensure you are on port 3846.'
@@ -475,13 +488,7 @@
           body: JSON.stringify({ workspace: WorkspaceContext.active })
         });
         status.textContent = 'Waiting for watcher to stop...';
-        let stopped = false;
-        for (let i = 0; i < 20; i++) {
-          await new Promise(r => setTimeout(r, 1000));
-          const sr = await WorkspaceContext.serviceFetch('/watcher-status');
-          const sd = await sr.json();
-          if (!sd.hasActiveWatcher) { stopped = true; break; }
-        }
+        const stopped = await waitForWatcherState(false, { maxAttempts: 20, intervalMs: 1000 });
         if (!stopped) {
           status.textContent = 'Watcher did not stop in time. Try closing it manually.';
           btn.textContent = 'Restart Watcher';
@@ -503,15 +510,14 @@
           return;
         }
         status.textContent = 'Waiting for new watcher...';
-        for (let i = 0; i < 30; i++) {
-          await new Promise(r => setTimeout(r, 2000));
-          const sr = await WorkspaceContext.serviceFetch('/watcher-status');
-          const sd = await sr.json();
-          if (sd.hasActiveWatcher) { loadAllWithOverview(); return; }
+        const started = await waitForWatcherState(true);
+        if (started) {
+          loadAllWithOverview();
+        } else {
+          status.textContent = 'Watcher started but still reconciling. Refresh shortly.';
+          btn.textContent = 'Restart Watcher';
+          btn.disabled = false;
         }
-        status.textContent = 'Watcher started but still reconciling. Refresh shortly.';
-        btn.textContent = 'Restart Watcher';
-        btn.disabled = false;
       } catch (err) {
         status.textContent = 'Error: ' + err.message;
         btn.textContent = 'Restart Watcher';
@@ -535,24 +541,14 @@
           return;
         }
         btn.textContent = 'Started';
-        let attempts = 0;
-        const poll = setInterval(async () => {
-          attempts++;
-          try {
-            const sr = await WorkspaceContext.serviceFetch('/watcher-status');
-            const sd = await sr.json();
-            if (sd.hasActiveWatcher) {
-              clearInterval(poll);
-              loadOverview();
-              loadWatcher();
-            }
-          } catch {}
-          if (attempts >= 30) {
-            clearInterval(poll);
-            btn.textContent = 'Start';
-            btn.disabled = false;
-          }
-        }, 2000);
+        const ok = await waitForWatcherState(true);
+        if (ok) {
+          loadOverview();
+          loadWatcher();
+        } else {
+          btn.textContent = 'Timed out';
+          setTimeout(() => { btn.textContent = 'Start'; btn.disabled = false; }, 5000);
+        }
       } catch (err) {
         btn.textContent = 'Error';
         setTimeout(() => { btn.textContent = 'Start'; btn.disabled = false; }, 5000);
@@ -588,24 +584,15 @@
       } catch {}
       document.getElementById('ov-service-dot').className = 'overview-dot dot-yellow';
       document.getElementById('ov-service-detail').textContent = 'Restarting...';
-      let attempts = 0;
-      const poll = setInterval(async () => {
-        attempts++;
-        try {
-          const resp = await WorkspaceContext.serviceFetch('/health');
-          if (resp.ok) {
-            clearInterval(poll);
-            loadAllWithOverview();
-          }
-        } catch {}
-        if (attempts >= 30) {
-          clearInterval(poll);
-          document.getElementById('ov-service-dot').className = 'overview-dot dot-red';
-          document.getElementById('ov-service-detail').textContent = 'Failed to restart \u2014 check logs';
-          btn.textContent = 'Restart';
-          btn.disabled = false;
-        }
-      }, 2000);
+      const ok = await waitForServiceHealth();
+      if (ok) {
+        loadAllWithOverview();
+      } else {
+        document.getElementById('ov-service-dot').className = 'overview-dot dot-red';
+        document.getElementById('ov-service-detail').textContent = 'Failed to restart \u2014 check logs';
+        btn.textContent = 'Restart';
+        btn.disabled = false;
+      }
     }
 
     // --- Projects card (merged config + stats + freshness) ---

--- a/src/parsers/angelscript-parser.js
+++ b/src/parsers/angelscript-parser.js
@@ -1,4 +1,5 @@
 import { readFile } from 'fs/promises';
+import { countBraces } from './parser-utils.js';
 
 // Keywords that should not be treated as return types for function detection
 const AS_KEYWORDS = new Set([
@@ -262,27 +263,3 @@ export function parseContent(content, filePath = '') {
   return result;
 }
 
-function countBraces(line) {
-  let delta = 0;
-  let inString = false;
-  let stringChar = '';
-  for (let i = 0; i < line.length; i++) {
-    const ch = line[i];
-    if (inString) {
-      if (ch === '\\') { i++; continue; }
-      if (ch === stringChar) inString = false;
-      continue;
-    }
-    if (ch === '"' || ch === "'") {
-      inString = true;
-      stringChar = ch;
-    } else if (ch === '/' && line[i + 1] === '/') {
-      break; // rest is comment
-    } else if (ch === '{') {
-      delta++;
-    } else if (ch === '}') {
-      delta--;
-    }
-  }
-  return delta;
-}

--- a/src/parsers/cpp-parser.js
+++ b/src/parsers/cpp-parser.js
@@ -1,4 +1,5 @@
 import { readFile } from 'fs/promises';
+import { countBraces } from './parser-utils.js';
 
 export async function parseCppFile(filePath) {
   const content = await readFile(filePath, 'utf-8');
@@ -381,27 +382,3 @@ function extractSpecifiers(line) {
   return match[1].split(',').map(s => s.trim()).filter(Boolean);
 }
 
-function countBraces(line) {
-  let delta = 0;
-  let inString = false;
-  let stringChar = '';
-  for (let i = 0; i < line.length; i++) {
-    const ch = line[i];
-    if (inString) {
-      if (ch === '\\') { i++; continue; }
-      if (ch === stringChar) inString = false;
-      continue;
-    }
-    if (ch === '"' || ch === "'") {
-      inString = true;
-      stringChar = ch;
-    } else if (ch === '/' && line[i + 1] === '/') {
-      break;
-    } else if (ch === '{') {
-      delta++;
-    } else if (ch === '}') {
-      delta--;
-    }
-  }
-  return delta;
-}

--- a/src/parsers/parser-utils.js
+++ b/src/parsers/parser-utils.js
@@ -1,0 +1,33 @@
+/**
+ * Count net brace depth change in a line, ignoring braces inside strings and
+ * single-line comments (// ...).
+ *
+ * Known limitation: block comments (/* ... *​/) are NOT handled — a brace
+ * inside a block comment will still be counted.  In practice this rarely
+ * causes issues because the parsers already skip lines that start with
+ * comment tokens, and multi-line block comments with braces are uncommon.
+ */
+export function countBraces(line) {
+  let delta = 0;
+  let inString = false;
+  let stringChar = '';
+  for (let i = 0; i < line.length; i++) {
+    const ch = line[i];
+    if (inString) {
+      if (ch === '\\') { i++; continue; }
+      if (ch === stringChar) inString = false;
+      continue;
+    }
+    if (ch === '"' || ch === "'") {
+      inString = true;
+      stringChar = ch;
+    } else if (ch === '/' && line[i + 1] === '/') {
+      break; // rest is comment
+    } else if (ch === '{') {
+      delta++;
+    } else if (ch === '}') {
+      delta--;
+    }
+  }
+  return delta;
+}

--- a/src/service/api.js
+++ b/src/service/api.js
@@ -414,7 +414,6 @@ export function createApi(database, indexer, queryPool = null, { zoektClient = n
     }
   }, 15000);
 
-  // Returns watcher heartbeat data including progress state (phase, projectProgress, watchedPaths)
   app.get('/watcher-status', (req, res) => {
     const watchers = [];
     const staleCutoff = Date.now() - 45000; // 3 missed heartbeats = stale


### PR DESCRIPTION
## Summary
- Extract duplicated `countBraces()` from angelscript-parser and cpp-parser into shared `parser-utils.js` with JSDoc documenting the known block comment limitation
- Replace 4 ad-hoc `setInterval`/for-loop poll patterns in `index.html` with reusable `waitForWatcherState()` and `waitForServiceHealth()` async helpers
- Add timeout feedback ("Timed out" button text) when overview watcher start polling exceeds max attempts
- Remove misleading comment on `/watcher-status` route in `api.js` that referenced non-existent progress state fields

## Test plan
- [x] `npm test` — all 55 tests pass (parser extraction verified)
- [x] Grep confirms no remaining `countBraces` in individual parsers
- [x] Grep confirms no remaining `setInterval` poll loops in index.html (only the 15s periodic refresh)
- [ ] Manual: open dashboard, test watcher Start/Stop/Restart buttons
- [ ] Manual: verify timeout feedback appears when watcher doesn't start

🤖 Generated with [Claude Code](https://claude.com/claude-code)