### PR TITLE
Include BUILD_GIT_HASH in generated docker-compose.yml

### DIFF
--- a/src/setup-gui.js
+++ b/src/setup-gui.js
@@ -151,7 +151,10 @@ function generateDockerCompose(wsConfig) {
     const swapGB = memGB + 2;
     const vol = ws.volumePrefix || name; // preserved across renames
     lines.push(`  ${name}:`);
-    lines.push(`    build: .`);
+    lines.push(`    build:`);
+    lines.push(`      context: .`);
+    lines.push(`      args:`);
+    lines.push(`        BUILD_GIT_HASH: \${BUILD_GIT_HASH:-unknown}`);
     lines.push(`    image: ${wsConfig.dockerImage}`);
     lines.push(`    container_name: unreal-index-${name}`);
     lines.push(`    ports:`);


### PR DESCRIPTION
## Summary
- The generated `docker-compose.yml` used `build: .` (string form) which didn't pass the `BUILD_GIT_HASH` build arg to the Dockerfile
- This caused a persistent version mismatch on the dashboard between the service (stale hash baked at image build time) and the watcher
- Only the setup GUI's rebuild button explicitly passed the arg; CLI builds via `docker compose build` produced `unknown`
- Switch to the mapping form (`context` + `args`) so `BUILD_GIT_HASH` is picked up from the environment, defaulting to `unknown`

## Test plan
- [ ] Run `npm run setup` or trigger workspace config save to regenerate `docker-compose.yml`
- [ ] Verify generated file contains `args: BUILD_GIT_HASH: ${BUILD_GIT_HASH:-unknown}` under each service
- [ ] Rebuild via CLI: `BUILD_GIT_HASH=$(git rev-parse --short HEAD) docker compose build`
- [ ] Verify `docker exec <container> cat /app/.git-hash` shows correct hash
- [ ] Check dashboard shows matching versions, no mismatch alert

🤖 Generated with [Claude Code](https://claude.com/claude-code)